### PR TITLE
Add bip32 support

### DIFF
--- a/verystable/bip32.py
+++ b/verystable/bip32.py
@@ -1,0 +1,281 @@
+# Copyright (c) 2021 Anthony Towns
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test-only bip32 implementation"""
+
+import csv
+import hashlib
+import hmac
+import os
+import random
+import struct
+import unittest
+
+from .core import secp256k1 as SECP256K1
+from .core.key import ECKey, ECPubKey
+from .core.script import hash256, hash160
+from .core.util import assert_equal
+
+chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+def byte_to_base58(b):
+    b = b + hash256(b)[:4]
+    result = ''
+    value = int('0x' + b.hex(), 0)
+    while value > 0:
+        result = chars[value % 58] + result
+        value //= 58
+    while (b[0] == b'\0'):
+        result = chars[0] + result
+        b = b[1:]
+    return result
+
+def base58_to_byte(s):
+    """Converts a base58-encoded string to its data"""
+    if not s:
+        return b''
+    n = 0
+    for c in s:
+        n *= 58
+        assert c in chars
+        digit = chars.index(c)
+        n += digit
+    h = '%x' % n
+    if len(h) % 2:
+        h = '0' + h
+    res = n.to_bytes((n.bit_length() + 7) // 8, 'big')
+    pad = 0
+    for c in s:
+        if c == chars[0]:
+            pad += 1
+        else:
+            break
+    res = b'\x00' * pad + res
+
+    # Assert if the checksum is invalid
+    assert_equal(hash256(res[:-4])[:4], res[-4:])
+
+    return res[:-4]
+
+class BIP32:
+    ver_xpub = 0x0488B21E
+    ver_xpriv = 0x0488ADE4
+    ver_tpub = 0x043587CF
+    ver_tpriv = 0x04358394
+
+    def __init__(self, key, public=None):
+        if isinstance(key, BIP32):
+            assert public is None
+            self.key = key.key
+            self.chain = key.chain
+            self.child = key.child
+            self.fprpar = key.fprpar
+            self.depth = key.depth
+            self.public = key.public
+        else:
+            self.gen_master(key)
+            self.public = (public == True)
+
+    def __repr__(self):
+        return self.serialize()
+
+    def gen_master(self, seed):
+        r = hmac.new(b'Bitcoin seed', msg=seed, digestmod=hashlib.sha512).digest()
+        IL,IR = r[:32], r[32:]
+        self.key = ECKey()
+        self.key.set(IL, compressed=True)
+        self.chain = IR
+        self.child = self.fprpar = self.depth = 0
+
+    def serialize(self):
+        assert isinstance(self.key, (ECKey, ECPubKey))
+        priv = isinstance(self.key, ECKey)
+        if self.public:
+            ver = self.ver_xpriv if priv else self.ver_xpub
+        else:
+            ver = self.ver_tpriv if priv else self.ver_tpub
+        s = struct.pack(">LBLL", ver, self.depth, self.fprpar, self.child)
+        s += self.chain
+        if priv:
+            s += bytes([0]) + self.key.get_bytes()
+        else:
+            s += self.key.get_bytes()
+        return byte_to_base58(s)
+
+    def deserialize(self, base58):
+        s = base58_to_byte(base58)
+        assert len(s) == 78
+        (ver, self.depth, self.fprpar, self.child) = struct.unpack(">LBLL", s[:13])
+        self.chain = s[13:45]
+        if ver in (self.ver_xpriv, self.ver_xpub):
+            self.public = True
+        elif ver in (self.ver_tpriv, self.ver_tpub):
+            self.public = False
+        else:
+            assert False, ("unknown ext key type %08x" % (ver))
+        if ver in (self.ver_xpriv, self.ver_tpriv):
+            assert s[45] == 0
+            self.key = ECKey()
+            self.key.set(s[46:78], compressed=True)
+            assert self.key.is_valid
+        else:
+            assert s[45] in (0x02, 0x03)
+            self.key = ECPubKey()
+            self.key.set(s[45:78])
+            assert self.key.is_valid
+
+        if self.depth == 0:
+            assert self.fprpar == 0 and self.child == 0
+
+        return self
+
+    def neuter(self):
+        if isinstance(self.key, ECKey):
+            r = BIP32(self)
+            r.key = r.key.get_pubkey()
+            return r
+        else:
+            return self
+
+    def fingerprint(self):
+        return int.from_bytes(hash160(self.neuter().key.get_bytes())[:4], 'big')
+
+    def derive(self, *path):
+        c = self
+        tweak = 0
+        for i in path:
+            c, t = c.derive_one(i)
+            tweak = (tweak + t) % SECP256K1.GE.ORDER
+        return c, tweak
+
+    def derive_one(self, i):
+        assert i == int(i) and 0 <= i < 2**32
+
+        child = BIP32(self)
+        child.child = i
+        child.fprpar = self.fingerprint()
+        child.depth += 1
+
+        if i < 2**31: # normal
+            d = self.neuter().key.get_bytes()
+        else: # hardened
+            assert isinstance(self.key, ECKey)
+            d = b"\0" + self.key.get_bytes()
+        d += struct.pack(">L", i)
+        h = hmac.new(self.chain, msg=d, digestmod=hashlib.sha512).digest()
+        IL, IR = h[:32], h[32:]
+
+        child.chain = IR
+
+        tweak = int.from_bytes(IL, "big")
+        if isinstance(self.key, ECPubKey):
+            child.key = ECPubKey()
+            child.key.compressed = self.key.compressed
+            child.key.p = self.key.p + (tweak * SECP256K1.G)
+        else:
+            child.key = ECKey()
+            child.key.secret = (self.key.secret + tweak) % SECP256K1.GE.ORDER
+            child.key.valid = self.key.valid and self.key.secret > 0
+            child.key.compressed = self.key.compressed
+
+        return child, tweak
+
+def bip32_tests():
+    from binascii import unhexlify
+    tests = { "000102030405060708090a0b0c0d0e0f": [
+                  ("xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8",
+                   "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
+                   0x80000000),
+                  ("xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw",
+                   "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
+                   1),
+                  ("xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ",
+                   "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs",
+                   0x80000002),
+                  ("xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5",
+                   "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM",
+                   2),
+                  ("xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV",
+                   "xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334",
+                   1000000000),
+                  ("xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy",
+                   "xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76",
+                   0) ],
+
+              "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542": [
+                  ("xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB",
+                   "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U",
+                   0),
+                  ("xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH",
+                   "xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt",
+                   0xFFFFFFFF),
+                  ("xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEyBLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a",
+                   "xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9",
+                   1),
+                  ("xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon",
+                   "xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef",
+                   0xFFFFFFFE),
+                  ("xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL",
+                   "xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc",
+                   2),
+                  ("xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt",
+                   "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j",
+                   0) ],
+
+              "4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45d239319ac14f863b8d5ab5a0d0c64d2e8a1e7d1457df2e5a3c51c73235be": [
+                  ("xpub661MyMwAqRbcEZVB4dScxMAdx6d4nFc9nvyvH3v4gJL378CSRZiYmhRoP7mBy6gSPSCYk6SzXPTf3ND1cZAceL7SfJ1Z3GC8vBgp2epUt13",
+                   "xprv9s21ZrQH143K25QhxbucbDDuQ4naNntJRi4KUfWT7xo4EKsHt2QJDu7KXp1A3u7Bi1j8ph3EGsZ9Xvz9dGuVrtHHs7pXeTzjuxBrCmmhgC6",
+                    0x80000000),
+                  ("xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y",
+                   "xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L",
+                    0) ],
+
+              "3ddd5602285899a946114506157c7997e5444528f3003f6134712147db19b678": [
+                  ("xpub661MyMwAqRbcGczjuMoRm6dXaLDEhW1u34gKenbeYqAix21mdUKJyuyu5F1rzYGVxyL6tmgBUAEPrEz92mBXjByMRiJdba9wpnN37RLLAXa",
+                   "xprv9s21ZrQH143K48vGoLGRPxgo2JNkJ3J3fqkirQC2zVdk5Dgd5w14S7fRDyHH4dWNHUgkvsvNDCkvAwcSHNAQwhwgNMgZhLtQC63zxwhQmRv",
+                   0x80000000),
+                  ("xpub69AUMk3qDBi3uW1sXgjCmVjJ2G6WQoYSnNHyzkmdCHEhSZ4tBok37xfFEqHd2AddP56Tqp4o56AePAgCjYdvpW2PU2jbUPFKsav5ut6Ch1m",
+                   "xprv9vB7xEWwNp9kh1wQRfCCQMnZUEG21LpbR9NPCNN1dwhiZkjjeGRnaALmPXCX7SgjFTiCTT6bXes17boXtjq3xLpcDjzEuGLQBM5ohqkao9G",
+                   0x80000001),
+                  ("xpub6BJA1jSqiukeaesWfxe6sNK9CCGaujFFSJLomWHprUL9DePQ4JDkM5d88n49sMGJxrhpjazuXYWdMf17C9T5XnxkopaeS7jGk1GyyVziaMt",
+                   "xprv9xJocDuwtYCMNAo3Zw76WENQeAS6WGXQ55RCy7tDJ8oALr4FWkuVoHJeHVAcAqiZLE7Je3vZJHxspZdFHfnBEjHqU5hG1Jaj32dVoS6XLT1",
+                   0) ],
+            }
+
+    invalid = [
+    "xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6LBpB85b3D2yc8sfvZU521AAwdZafEz7mnzBBsz4wKY5fTtTQBm",
+    "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFGTQQD3dC4H2D5GBj7vWvSQaaBv5cxi9gafk7NF3pnBju6dwKvH",
+    "xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6Txnt3siSujt9RCVYsx4qHZGc62TG4McvMGcAUjeuwZdduYEvFn",
+    "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFGpWnsj83BHtEy5Zt8CcDr1UiRXuWCmTQLxEK9vbz5gPstX92JQ",
+    "xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6N8ZMMXctdiCjxTNq964yKkwrkBJJwpzZS4HS2fxvyYUA4q2Xe4",
+    "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD9y5gkZ6Eq3Rjuahrv17fEQ3Qen6J",
+    "xprv9s2SPatNQ9Vc6GTbVMFPFo7jsaZySyzk7L8n2uqKXJen3KUmvQNTuLh3fhZMBoG3G4ZW1N2kZuHEPY53qmbZzCHshoQnNf4GvELZfqTUrcv",
+    "xpub661no6RGEX3uJkY4bNnPcw4URcQTrSibUZ4NqJEw5eBkv7ovTwgiT91XX27VbEXGENhYRCf7hyEbWrR3FewATdCEebj6znwMfQkhRYHRLpJ",
+    "xprv9s21ZrQH4r4TsiLvyLXqM9P7k1K3EYhA1kkD6xuquB5i39AU8KF42acDyL3qsDbU9NmZn6MsGSUYZEsuoePmjzsB3eFKSUEh3Gu1N3cqVUN",
+    "xpub661MyMwAuDcm6CRQ5N4qiHKrJ39Xe1R1NyfouMKTTWcguwVcfrZJaNvhpebzGerh7gucBvzEQWRugZDuDXjNDRmXzSZe4c7mnTK97pTvGS8",
+    "DMwo58pR1QLEFihHiXPVykYB6fJmsTeHvyTp7hRThAtCX8CvYzgPcn8XnmdfHGMQzT7ayAmfo4z3gY5KfbrZWZ6St24UVf2Qgo6oujFktLHdHY4",
+    "DMwo58pR1QLEFihHiXPVykYB6fJmsTeHvyTp7hRThAtCX8CvYzgPcn8XnmdfHPmHJiEDXkTiJTVV9rHEBUem2mwVbbNfvT2MTcAqj3nesx8uBf9",
+    "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzF93Y5wvzdUayhgkkFoicQZcP3y52uPPxFnfoLZB21Teqt1VvEHx",
+    "xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD5SDKr24z3aiUvKr9bJpdrcLg1y3G",
+    "xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6Q5JXayek4PRsn35jii4veMimro1xefsM58PgBMrvdYre8QyULY",
+    "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHL",
+    ]
+
+    for seed, hier in tests.items():
+        b = BIP32(unhexlify(seed.encode('utf8')), public=True)
+        for pub, priv, i in hier:
+            assert pub == b.neuter().serialize()
+            assert priv == b.serialize()
+            assert BIP32(b'').deserialize(pub).serialize() == pub
+            assert BIP32(b'').deserialize(priv).serialize() == priv
+            c, t = b.derive(i)
+            if i < 2**31:
+                assert b.neuter().derive(i)[0].serialize() == c.neuter().serialize()
+            b = c
+
+    for inv in invalid:
+        failed = False
+        try:
+            BIP32(b'').deserialize(inv)
+        except AssertionError:
+            failed = True
+        assert failed, "%s deserialized okay??" % (inv,)


### PR DESCRIPTION
Adds support for bip32 (HD wallets), generating pubkeys and privkeys from seeds, and converting from xpub/xprv encodings.